### PR TITLE
adding pybind11 wrapper

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
         python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,11 +12,11 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install xmllint
-      run: sudo apt-get install -y libyaml-cpp-dev
     - name: Build and install
       run: pip install .[test]
     - name: Test

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, windows-latest]
         python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -17,6 +17,10 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install OS requirements
+      uses: mstksg/get-package@v1
+      with:
+        brew: gcc
     - name: Build and install
       run: pip install .[test]
     - name: Test

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,0 +1,21 @@
+name: "pip"
+
+on: push
+
+jobs:
+  build:
+    name: Build with Pip
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-latest]
+        python-version: [3.8, 3.9, "3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Build and install
+      run: pip install --verbose .[test]
+    - name: Test
+      run: pytest

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -6,6 +6,9 @@ on:
     types:
       - published
 
+env:
+  FC: gfortran-11
+
 jobs:
   build:
     name: Build with Pip

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        platform: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -17,11 +16,23 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install OS requirements
-      uses: mstksg/get-package@v1
-      with:
-        brew: gfortran
     - name: Build and install
       run: pip install .[test]
     - name: Test
       run: pytest tests
+    - name: Build wheels
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel
+        python setup.py sdist
+    - uses: pypa/cibuildwheel@v2.11.2
+      env:
+        CIBW_ARCHS_MACOS: auto universal2
+    - name: Store wheels as artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: |
+          dist
+          wheelhouse/*.whl
+

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install xmllint
-      run: sudo apt-get install -y libgsl-dev libyaml-cpp-dev
+      run: sudo apt-get install -y libyaml-cpp-dev
     - name: Build and install
       run: pip install .[test]
     - name: Test

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -21,17 +21,25 @@ jobs:
       run: pip install .[test]
     - name: Test
       run: pytest tests
-    - name: Build wheels
-      run: |
-        python setup.py sdist
-    - uses: pypa/cibuildwheel@v2.11.2
-      env:
-        CIBW_ARCHS_MACOS: auto universal2
-    - name: Store wheels as artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheels
-        path: |
-          dist
-          wheelhouse/*.whl
 
+  build_sdist:
+    name: Build sdist
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: [3.9]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Build SDist
+      run: pipx run build --sdist
+    - name: Check metadata
+      run: pipx run twine check dist/*
+    - uses: actions/upload-artifact@v3
+      with:
+        path: dist/*.tar.gz

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -6,9 +6,6 @@ on:
     types:
       - published
 
-env:
-  FC: gfortran-11
-
 jobs:
   build:
     name: Build with Pip
@@ -24,6 +21,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install GNU Fortran
+      uses: modflowpy/install-gfortran-action@v1
     - name: Build and install
       run: pip install .[test]
     - name: Test
@@ -54,6 +53,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+    - name: Install GNU Fortran
+      uses: modflowpy/install-gfortran-action@v1
     - uses: pypa/cibuildwheel@v2.11.2
       env:
         CIBW_ARCHS_MACOS: auto universal2

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install xmllint
-      run: sudo apt-get install -y libgsl-dev yaml-cpp
+      run: sudo apt-get install -y libgsl-dev libyaml-cpp-dev
     - name: Build and install
       run: pip install .[test]
     - name: Test

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -8,14 +8,16 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [ubuntu-latest]
         python-version: [3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install xmllint
+      run: sudo apt-get install -y libgsl-dev yaml-cpp
     - name: Build and install
-      run: pip install --verbose .[test]
+      run: pip install .[test]
     - name: Test
       run: pytest

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install OS requirements
       uses: mstksg/get-package@v1
       with:
-        brew: gcc
+        brew: gfortran
     - name: Build and install
       run: pip install .[test]
     - name: Test

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,6 +1,10 @@
-name: "pip"
+name: "Build wheels and deploy"
 
-on: push
+on:
+  push:
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -64,3 +68,20 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         path: wheelhouse/*.whl
+
+  # upload_all:
+  #   name: Upload if release
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'release' && github.event.action == 'published'
+  #   steps:
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: "3.x"
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: artifact
+  #       path: dist
+  #   - uses: pypa/gh-action-pypi-publish@master
+  #     with:
+  #       password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -23,8 +23,6 @@ jobs:
       run: pytest tests
     - name: Build wheels
       run: |
-        python -m pip install --upgrade pip
-        pip install wheel
         python setup.py sdist
     - uses: pypa/cibuildwheel@v2.11.2
       env:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Build and install
       run: pip install .[test]
     - name: Test
-      run: pytest
+      run: pytest tests

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -11,6 +11,7 @@ jobs:
     name: Build with Pip
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]
@@ -47,6 +48,7 @@ jobs:
     name: Wheels on ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -28,18 +28,11 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        platform: [ubuntu-latest]
-        python-version: [3.9]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Build SDist
       run: pipx run build --sdist
     - name: Check metadata
@@ -54,7 +47,6 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -62,7 +54,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.11.2
       env:
         CIBW_ARCHS_MACOS: auto universal2
-        CIBW_SKIP: pp* cp36-* *-musllinux *_i686
+        CIBW_SKIP: pp* cp36-* *-musllinux_x86_64 *_i686
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -62,6 +62,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.11.2
       env:
         CIBW_ARCHS_MACOS: auto universal2
+        CIBW_SKIP: pp* cp36-* *-musllinux *_i686
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
         python-version: [3.9]
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -43,3 +43,24 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         path: dist/*.tar.gz
+
+  build_wheels:
+    name: Wheels on ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: [3.9]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: pypa/cibuildwheel@v2.11.2
+      env:
+        CIBW_ARCHS_MACOS: auto universal2
+    - name: Verify clean directory
+      run: git diff --exit-code
+      shell: bash
+    - uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/yaml-cpp"]
+	path = external/yaml-cpp
+	url = https://github.com/jbeder/yaml-cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 enable_language(Fortran)
 
 find_package(PkgConfig REQUIRED)
-pkg_search_module(GSL REQUIRED gsl)
 pkg_search_module(YAML REQUIRED yaml-cpp)
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
@@ -33,9 +32,7 @@ configure_file(
     )
 
 add_definitions(-DDATA_PATH="${prefix}/share/fiatlux")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${YAMLCPP_CFLAGS} ${GSL_CFLAGS} -std=c++11")
-include_directories(src ${GSL_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
-
+include_directories(src ${YAML_INCLUDE_DIRS})
 
 option(PYTHON_ONLY "Compiles only for python." OFF)
 if(PYTHON_ONLY)
@@ -59,7 +56,7 @@ if(PYTHON_ONLY)
                            src/F2N.f
                            src/HERMES-ALLM-gd-fit-11.f)
   target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
-  target_link_libraries(_core PRIVATE ${GSL_LDFLAGS} ${YAML_LDFLAGS})
+  target_link_libraries(_core PRIVATE ${YAML_LDFLAGS})
   install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsOnly_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
   install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsAndPolarized_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
   install(TARGETS _core DESTINATION .)
@@ -82,7 +79,7 @@ else()
                             src/F2N.f
                             src/HERMES-ALLM-gd-fit-11.f
                           )
-  target_link_libraries(fiatlux ${GSL_LDFLAGS} ${YAML_LDFLAGS})
+  target_link_libraries(fiatlux ${YAML_LDFLAGS})
 
   install(FILES ${PROJECT_SOURCE_DIR}/scripts/fiatlux-config
     DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.15..3.22)
+
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -9,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # the project name
-project(fiatlux)
+project(fiatlux VERSION "0.1.0")
 
 # activating some global properties for the project
 set(CMAKE_CXX_STANDARD 11)
@@ -18,34 +19,37 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 enable_language(Fortran)
 
-# export version to file
-set(VERSION "\"0.0.2\"")
-configure_file(
-  "${PROJECT_SOURCE_DIR}/src/fiatlux/config.h.in"
-  "${PROJECT_SOURCE_DIR}/src/fiatlux/config.h"
-  )
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GSL REQUIRED gsl)
+pkg_search_module(YAML REQUIRED yaml-cpp)
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "${prefix}")
 set(includedir "${prefix}/include")
 set(libdir "${prefix}/lib")
 configure_file(
-  "${PROJECT_SOURCE_DIR}/scripts/fiatlux-config.in"
-  "${PROJECT_SOURCE_DIR}/scripts/fiatlux-config"
-)
-configure_file(
-  "${PROJECT_SOURCE_DIR}/scripts/fiatlux.pc.in"
-  "${PROJECT_SOURCE_DIR}/scripts/fiatlux.pc"
-)
-
-find_package(PkgConfig REQUIRED)
-pkg_search_module(GSL REQUIRED gsl)
-pkg_search_module(YAML REQUIRED yaml-cpp)
+    "${PROJECT_SOURCE_DIR}/src/fiatlux/config.h.in"
+    "${PROJECT_SOURCE_DIR}/src/fiatlux/config.h"
+    )
 
 add_definitions(-DDATA_PATH="${prefix}/share/fiatlux")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${YAMLCPP_CFLAGS} ${GSL_CFLAGS} -std=c++11")
 include_directories(src ${GSL_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
-add_library(fiatlux SHARED src/fiatlux.cc
+
+
+option(PYTHON_ONLY "Compiles only for python." OFF)
+if(PYTHON_ONLY)
+  if(SKBUILD)
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c
+              "import pybind11; print(pybind11.get_cmake_dir())"
+      OUTPUT_VARIABLE _tmp_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+    list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+  endif()
+  find_package(pybind11 CONFIG REQUIRED)
+  pybind11_add_module(_core MODULE src/pywrapper.cc
+                           src/fiatlux.cc
                            src/elastic.cc
                            src/inelastic.cc
                            src/integrator.cc
@@ -53,20 +57,43 @@ add_library(fiatlux SHARED src/fiatlux.cc
                            src/proton.cc
                            src/settings.cc
                            src/F2N.f
-                           src/HERMES-ALLM-gd-fit-11.f
-                         )
+                           src/HERMES-ALLM-gd-fit-11.f)
+  target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
+  target_link_libraries(_core PRIVATE ${GSL_LDFLAGS} ${YAML_LDFLAGS})
+  install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsOnly_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
+  install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsAndPolarized_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
+  install(TARGETS _core DESTINATION .)
+else()
+  configure_file(
+    "${PROJECT_SOURCE_DIR}/scripts/fiatlux-config.in"
+    "${PROJECT_SOURCE_DIR}/scripts/fiatlux-config"
+  )
+  configure_file(
+    "${PROJECT_SOURCE_DIR}/scripts/fiatlux.pc.in"
+    "${PROJECT_SOURCE_DIR}/scripts/fiatlux.pc"
+  )
+  add_library(fiatlux SHARED src/fiatlux.cc
+                            src/elastic.cc
+                            src/inelastic.cc
+                            src/integrator.cc
+                            src/msbar.cc
+                            src/proton.cc
+                            src/settings.cc
+                            src/F2N.f
+                            src/HERMES-ALLM-gd-fit-11.f
+                          )
+  target_link_libraries(fiatlux ${GSL_LDFLAGS} ${YAML_LDFLAGS})
 
-target_link_libraries(fiatlux ${GSL_LDFLAGS} ${YAML_LDFLAGS})
+  install(FILES ${PROJECT_SOURCE_DIR}/scripts/fiatlux-config
+    DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+  install(FILES ${PROJECT_SOURCE_DIR}/scripts/fiatlux.pc DESTINATION lib/pkgconfig)
+  install(DIRECTORY src/fiatlux DESTINATION include)
+  install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsOnly_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
+  install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsAndPolarized_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
+  install(TARGETS fiatlux DESTINATION lib)
 
-install(FILES ${PROJECT_SOURCE_DIR}/scripts/fiatlux-config
-	DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-install(FILES ${PROJECT_SOURCE_DIR}/scripts/fiatlux.pc DESTINATION lib/pkgconfig)
-install(DIRECTORY src/fiatlux DESTINATION include)
-install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsOnly_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
-install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsAndPolarized_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
-install(TARGETS fiatlux DESTINATION lib)
-
-option(ENABLE_EXAMPLES "Enable examples." OFF)
-if(ENABLE_EXAMPLES)
-  add_subdirectory(examples)
+  option(ENABLE_EXAMPLES "Enable examples." OFF)
+  if(ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+  endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,8 @@ project(fiatlux VERSION "0.1.0")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fPIC")
 enable_language(Fortran)
-
-find_package(PkgConfig REQUIRED)
-pkg_search_module(YAML REQUIRED yaml-cpp)
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "${prefix}")
@@ -32,7 +29,8 @@ configure_file(
     )
 
 add_definitions(-DDATA_PATH="${prefix}/share/fiatlux")
-include_directories(src ${YAML_INCLUDE_DIRS})
+include_directories(src)
+add_subdirectory(external/yaml-cpp)
 
 option(PYTHON_ONLY "Compiles only for python." OFF)
 if(PYTHON_ONLY)
@@ -56,7 +54,7 @@ if(PYTHON_ONLY)
                            src/F2N.f
                            src/HERMES-ALLM-gd-fit-11.f)
   target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
-  target_link_libraries(_core PRIVATE ${YAML_LDFLAGS})
+  target_link_libraries(_core PRIVATE yaml-cpp)
   install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsOnly_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
   install(FILES ${PROJECT_SOURCE_DIR}/data/CrossSectionsAndPolarized_SplinesWithVariableKnots.dat DESTINATION share/fiatlux)
   install(TARGETS _core DESTINATION .)
@@ -79,7 +77,7 @@ else()
                             src/F2N.f
                             src/HERMES-ALLM-gd-fit-11.f
                           )
-  target_link_libraries(fiatlux ${YAML_LDFLAGS})
+  target_link_libraries(fiatlux yaml-cpp)
 
   install(FILES ${PROJECT_SOURCE_DIR}/scripts/fiatlux-config
     DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ API for LUXqed methodology in global PDF fits.
 
 The aim of `libfiatlux` is to provide a blackbox tool which computed the photon PDF at a given Q value
 using the LUX approach by Manohar, Nason, Salam and Zanderighi in [arXiv:1607.04266](https://arxiv.org/abs/1607.04266) and [arXiv:1708.01256](https://arxiv.org/abs/1708.01256). The output of this repository is a C++ library
-which can be imported and shared to other programs. 
+which can be imported and shared to other programs.
 
 The library implements following features:
 - Computes LUX photon by subdiving in elastic, inelastic and msbar components
@@ -16,7 +16,7 @@ The library implements following features:
 
 ### Release and Tag policy
 
-The library is tagged and released when a major and stable status is achieved. 
+The library is tagged and released when a major and stable status is achieved.
 
 ### Testing
 
@@ -24,10 +24,17 @@ Manual testes are available in the `examples` folder.
 
 ## Installation
 
+### Python library
+
+```Shell
+pip install .
+```
+
+### C++ library
+
 `libfialux` depends on the following libraries:
 
 - pkg-config
-- gsl
 - yaml-cpp
 
 optinally to build the examples:
@@ -79,5 +86,5 @@ If you decide to use this code please cite the following papers:
 - The NNPDF3.1QED paper which is the fundamental motivation for this library [arXiv:1712.07053](https://arxiv.org/abs/1712.07053)
 - The original LUX paper [arXiv:1607.04266](https://arxiv.org/abs/1607.04266)
 - The long/complete version of LUX [arXiv:1708.01256](https://arxiv.org/abs/1708.01256)
-- The GD11-P fit code from: The HERMES Collaboration [A. Airapetian et al.], JHEP 05 (2011) 126. 
+- The GD11-P fit code from: The HERMES Collaboration [A. Airapetian et al.], JHEP 05 (2011) 126.
 - The CLAS parametrisation used in hep-ph/0301204 (CLAS) and described in hep-ph/9901360.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "pybind11>=2.9.2",
+    "cmake>=3.22",
+    "scikit-build>=0.15.0",
+]
+build-backend = "setuptools.build_meta"

--- a/scripts/fiatlux-config.in
+++ b/scripts/fiatlux-config.in
@@ -38,6 +38,6 @@ test -n "$tmp" && OUT="$OUT -L@libdir@ -lfiatlux -std=c++11 -lgfortran"
 
 ## Version
 tmp=$( echo "$*" | egrep -- '--\<version\>')
-test -n "$tmp" && OUT="$OUT @PACKAGE_VERSION@"
+test -n "$tmp" && OUT="$OUT @PROJECT_VERSION@"
 
 echo $OUT

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+import sys
+
+try:
+    from skbuild import setup
+except ImportError:
+    print(
+        "Please update pip, you need pip 10 or greater,\n"
+        " or you need to install the PEP 518 requirements in pyproject.toml yourself",
+        file=sys.stderr,
+    )
+    raise
+
+from setuptools import find_packages
+
+setup(
+    name="fiatlux",
+    version="0.1.0",
+    description="API for LUXqed methodology in global PDF fits",
+    author="Stefano Carrazza",
+    license="AGPLv3",
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    cmake_install_dir="src/fiatlux",
+    cmake_args=['-DPYTHON_ONLY:BOOL=ON'],
+    extras_require={"test": ["pytest"]},
+    python_requires=">=3.6",
+)

--- a/src/fiatlux/__init__.py
+++ b/src/fiatlux/__init__.py
@@ -1,0 +1,1 @@
+from ._core import __version__, FiatLux

--- a/src/fiatlux/config.h.in
+++ b/src/fiatlux/config.h.in
@@ -1,1 +1,1 @@
-#define VERSION @VERSION@
+#define VERSION "@PROJECT_VERSION@"

--- a/src/pywrapper.cc
+++ b/src/pywrapper.cc
@@ -1,0 +1,37 @@
+// pybind11 includes
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include <pybind11/stl.h>
+
+// namespaces
+#include "fiatlux/fiatlux.h"
+
+// namespaces
+using namespace fiatlux;
+namespace py = pybind11;
+
+// macros
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
+
+PYBIND11_MODULE(_core, m) {
+    py::class_<FiatLux>(m, "FiatLux")
+        .def(py::init<const std::string &>())
+        .def("PlugAlphaQED", &FiatLux::PlugAlphaQED)
+        .def("PlugStructureFunctions", &FiatLux::PlugStructureFunctions)
+        .def("InsertInelasticSplitQ", &FiatLux::InsertInelasticSplitQ)
+        .def("EvaluatePhoton", &FiatLux::EvaluatePhoton);
+
+    py::class_<luxqed>(m, "luxqed")
+        .def(py::init())
+        .def_readonly("elastic", &luxqed::elastic)
+        .def_readonly("inelastic_pf", &luxqed::inelastic_pf)
+        .def_readonly("msbar_pf", &luxqed::msbar_pf)
+        .def_readonly("total", &luxqed::total);
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+#else
+    m.attr("__version__") = "dev";
+#endif
+}

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,0 +1,29 @@
+import fiatlux
+
+
+def a(q):
+    return 0.1
+
+
+def f2(x, q):
+    return 0.
+
+
+def fl(x, q):
+    return 0.
+
+
+def f2lo(x, q):
+    return 0.
+
+
+def test_loading():
+    lux = fiatlux.FiatLux("examples/runcard.yml")
+    lux.PlugAlphaQED(a, 0.0005)
+    lux.PlugStructureFunctions(f2, fl, f2lo)
+    lux.InsertInelasticSplitQ([4.18, 1e100])
+    pht = lux.EvaluatePhoton(0.1, 1000)
+    assert pht.elastic == 0.0601621248523242
+    assert pht.inelastic_pf == 0.01927555943602428
+    assert pht.msbar_pf == 0.0
+    assert pht.total == 0.07943768428834848


### PR DESCRIPTION
Implements a python wrapper based on pybind11.

**Installation**
```
# install gsl then
pip install .
```
**Test code**

```python
import fiatlux
import numpy as np

def a(q):
    return 0.1

def f2(x, q):
    return 0.

def fl(x, q):
    return 0.

def f2lo(x, q):
    return 0.

lux = fiatlux.FiatLux("examples/runcard.yml")
lux.PlugAlphaQED(a, 0.0005)
lux.PlugStructureFunctions(f2, fl, f2lo)
lux.InsertInelasticSplitQ([4.18, 1e100])

y_of_zeta = lambda y, a: y + a**(1 - np.exp(-y))
q2 = 1e4

print("x, Q2, elastic, inelastic, msbar, total")
for i in range(1, 101):
    y = y_of_zeta(i * 0.1, 0)
    x = np.exp(-y)
    pht = lux.EvaluatePhoton(x, q2)
    print(f"{x} {q2} {pht.elastic} {pht.inelastic_pf} {pht.msbar_pf} {pht.total}")

```