### PR TITLE
Bump version and build for python 3.13

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -29,15 +29,16 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install GNU Fortran
         uses: fortran-lang/setup-fortran@v1
         with:
           version: 13
-      - uses: pypa/cibuildwheel@v2.16
+      - uses: pypa/cibuildwheel@v3.1.4
         env:
-          CIBW_ARCHS_MACOS: auto x86_64 arm64
+          CIBW_ARCHS_MACOS: auto arm64
           CIBW_SKIP: pp* cp36-* *-musllinux_x86_64 *_i686
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
       - name: Verify clean directory
         run: git diff --exit-code
         shell: bash
@@ -54,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-14]
-        python-version: ["3.10"]
+        python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # the project name
-project(fiatlux VERSION "0.1.4")
+project(fiatlux VERSION "0.1.5")
 
 # activating some global properties for the project
 set(CMAKE_CXX_STANDARD 11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,3 @@ requires = [
     "scikit-build>=0.15.0",
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.cibuildwheel]
-# The only missing wheel at the moment is 3.13
-build = "cp313-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,7 @@ requires = [
     "scikit-build>=0.15.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+# The only missing wheel at the moment is 3.13
+build = "cp313-*"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="fiatlux",
-    version="0.1.4",
+    version="0.1.5",
     description="API for LUXqed methodology in global PDF fits",
     author="Stefano Carrazza",
     license="AGPLv3",


### PR DESCRIPTION
This closes #12 by building for python 3.13 for both Linux and MacOS with no other changes to the code.

I bumped also the version to 0.1.5 to keep it separated.

Since there were no changes to the code. I pushed the artefacts myself to pypi since I have access to the account there. If this is to be merged it probably needs to be built in all versions.

Leaving it here in case someone starts working on this again.